### PR TITLE
Kludges appearance fixes

### DIFF
--- a/pkg/ui/editor/colorscheme.go
+++ b/pkg/ui/editor/colorscheme.go
@@ -165,7 +165,7 @@ func StringToColor(str string) tcell.Color {
 		return tcell.ColorTeal
 	case "white":
 		return tcell.ColorSilver
-	case "brightblack", "lightblack":
+	case "brightblack", "lightblack", "grey", "gray":
 		return tcell.ColorGray
 	case "brightred", "lightred":
 		return tcell.ColorRed

--- a/pkg/ui/editor/view.go
+++ b/pkg/ui/editor/view.go
@@ -151,7 +151,7 @@ func (v *View) OpenBuffer(buf *Buffer) {
 	color-link origin "bold white"
 	color-link tearline "bold white"
 	color-link tagline "bold white"
-	color-link kludge "bold black"
+	color-link kludge "bold gray"
 	`))
 }
 

--- a/pkg/ui/help.go
+++ b/pkg/ui/help.go
@@ -91,12 +91,13 @@ Ins, Ctrl-I    Enter a new message
 Del            Delete current/marked message(s), ask first
 Right/Left     Next/Previous message
 Home/End       Display first/last part of current message
-</>            Go to First/Last mesage
+</>            Go to First/Last message
 Ctrl-G         Go to message number
 F3, Ctrl-Q     Quote-Reply to message. (Reply to FROM name)
 Ctrl-N         Quote-Reply in another area
 Ctrl-L         Enter the Message Lister
 Ctrl-F         Forward message to another area
+Alt-K          Show Kludges
 `).
 		SetDoneFunc(func() {
 			a.Pages.HidePage("ViewMsgHelp")


### PR DESCRIPTION
Currently kludges are not visible in message view when pressing Alt+K key
They are displayed as "bold black" color

Have added "gray", "grey" aliases in color config
Have made "bold gray" color for kludges
Have added "Alt-K" hotkey description in message window help
