### PR TITLE
Handle Esc key in header editing to cancel message creation

### DIFF
--- a/pkg/ui/editheader.go
+++ b/pkg/ui/editheader.go
@@ -22,6 +22,7 @@ type EditHeader struct {
 	sPosition [5]int
 	sCoords   [5]coords
 	done      func([5][]rune)
+	cancel    func()
 	msg       *msgapi.Message
         app       *App
 }
@@ -92,6 +93,10 @@ func (e *EditHeader) InputHandler() func(event *tcell.EventKey, setFocus func(p 
 			e.sPosition[e.sIndex]++
 		}
 		switch key := event.Key(); key {
+		case tcell.KeyEsc:
+			if e.cancel != nil {
+				e.cancel()
+			}
 		case tcell.KeyTab:
                         if (e.sIndex == 2 || e.sIndex == 3) {
                                 e.app.Pages.AddPage(e.showNodeList())
@@ -143,6 +148,12 @@ func (e *EditHeader) InputHandler() func(event *tcell.EventKey, setFocus func(p 
 // SetDoneFunc callback
 func (e *EditHeader) SetDoneFunc(handler func([5][]rune)) *EditHeader {
 	e.done = handler
+	return e
+}
+
+// SetCancelFunc callback for cancel (Esc)
+func (e *EditHeader) SetCancelFunc(handler func()) *EditHeader {
+	e.cancel = handler
 	return e
 }
 

--- a/pkg/ui/insertmsg.go
+++ b/pkg/ui/insertmsg.go
@@ -25,6 +25,7 @@ type IM struct {
 	postArea   *msgapi.AreaPrimitive
 	newMsgType int
 	buffer     *editor.Buffer
+	bodyEdited bool
 }
 
 // InsertMsgMenu modal menu
@@ -129,7 +130,16 @@ func (a *App) InsertMsg(area *msgapi.AreaPrimitive, msgType int) (string, tview.
 		/*
 			a.im.eb.SetText(mv, p)
 		}*/
+		a.im.bodyEdited = true
 		a.App.SetFocus(a.im.eb)
+	})
+	a.im.eh.SetCancelFunc(func() {
+		if a.im.bodyEdited {
+			return
+		}
+		a.Pages.SwitchToPage(fmt.Sprintf("ViewMsg-%s-%d", (*a.im.curArea).GetName(), (*a.im.curArea).GetLast()))
+		a.Pages.RemovePage(fmt.Sprintf("InsertMsg-%s", (*a.im.curArea).GetName()))
+		a.App.SetFocus(a.Pages)
 	})
 	layout := tview.NewFlex().
 		SetDirection(tview.FlexRow).

--- a/pkg/ui/insertmsg.go
+++ b/pkg/ui/insertmsg.go
@@ -67,6 +67,7 @@ func (a *App) InsertMsg(area *msgapi.AreaPrimitive, msgType int) (string, tview.
 	var omsg *msgapi.Message
 	a.im.curArea = area
 	a.im.newMsgType = msgType
+	a.im.bodyEdited = false
 	if a.im.newMsgType == 0 || a.im.newMsgType == newMsgTypeAnswer {
 		a.im.postArea = area
 	}


### PR DESCRIPTION
Esc drops the new message and returns to message reading when the body hasn't been edited yet; otherwise it is ignored to prevent data loss.

Closes #261 