### PR TITLE
Add quoted strings word-wrapping

### DIFF
--- a/gossiped.example.yml
+++ b/gossiped.example.yml
@@ -23,5 +23,7 @@ sorting:
   areas: unread   # unread, default
 statusbar:
   clock: true
+# quote margin in characters; 0 disables wrapping (default: 72)
+#quotemargin: 72
 citypath: ./city.yml
 nodelistpath: ''

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,7 @@ type (
 		Origin      string
 		Tearline    string
 		Template    string
+		QuoteMargin *int
 		Chrs        struct {
 			Default string
 			IBMPC   string
@@ -102,6 +103,10 @@ func Read(fn string) error {
 	readTemplate(tpl)
 	if len(Config.Tearline) == 0 {
 		Config.Tearline = LongPID
+	}
+	if Config.QuoteMargin == nil {
+		qm := 72
+		Config.QuoteMargin = &qm
 	}
 	errColors := readColors(rootPath)
 	if errColors != nil {

--- a/pkg/msgapi/message.go
+++ b/pkg/msgapi/message.go
@@ -250,15 +250,17 @@ func wrapQuoteLine(prefix, body string, margin int) []string {
 	var segments []string
 	for len(runes) > avail {
 		cut := avail
-		spaceIdx := -1
-		for i := avail - 1; i > 0; i-- {
-			if runes[i] == ' ' {
-				spaceIdx = i
-				break
+		if runes[avail] != ' ' {
+			spaceIdx := -1
+			for i := avail - 1; i > 0; i-- {
+				if runes[i] == ' ' {
+					spaceIdx = i
+					break
+				}
 			}
-		}
-		if spaceIdx > 0 {
-			cut = spaceIdx
+			if spaceIdx > 0 {
+				cut = spaceIdx
+			}
 		}
 		segment := string(runes[:cut])
 		runes = runes[cut:]

--- a/pkg/msgapi/message.go
+++ b/pkg/msgapi/message.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/askovpen/gossiped/pkg/config"
 	"github.com/askovpen/gossiped/pkg/types"
@@ -235,6 +236,50 @@ func (m *Message) GetForward() []string {
 	return nm
 }
 
+// wrapQuoteLine wraps body to margin runes per segment with prefix prepended.
+// margin == 0 disables wrapping.
+func wrapQuoteLine(prefix, body string, margin int) []string {
+	avail := margin - utf8.RuneCountInString(prefix)
+	if margin <= 0 || avail <= 0 || utf8.RuneCountInString(body) <= avail {
+		return []string{prefix + body}
+	}
+	runes := []rune(body)
+	var segments []string
+	for len(runes) > avail {
+		cut := avail
+		spaceIdx := -1
+		for i := avail - 1; i > 0; i-- {
+			if runes[i] == ' ' {
+				spaceIdx = i
+				break
+			}
+		}
+		if spaceIdx > 0 {
+			cut = spaceIdx
+		}
+		segment := string(runes[:cut])
+		runes = runes[cut:]
+		for len(runes) > 0 && runes[0] == ' ' {
+			runes = runes[1:]
+		}
+		segments = append(segments, prefix+segment)
+	}
+	if len(runes) > 0 {
+		segments = append(segments, prefix+string(runes))
+	}
+	return segments
+}
+
+// splitSep extracts leading spaces from s as a separator and returns (sep, body).
+// If s has no leading spaces, sep defaults to a single space per FSC-0032.
+func splitSep(s string) (sep, body string) {
+	body = strings.TrimLeft(s, " ")
+	if len(body) == len(s) {
+		return " ", s
+	}
+	return s[:len(s)-len(body)], body
+}
+
 // GetQuote get quote
 func (m *Message) GetQuote() []string {
 	var nm []string
@@ -248,20 +293,34 @@ func (m *Message) GetQuote() []string {
 			continue
 		} else if len(l) > 8 && l[0:9] == "SEEN-BY: " {
 			continue
-		} else if ind := re.FindStringIndex(l); ind != nil {
+		}
+		ind := re.FindStringIndex(l)
+		// blank lines stay blank (no prefix).
+		if (ind == nil && strings.TrimSpace(l) == "") ||
+			(ind != nil && strings.TrimSpace(l[ind[1]:]) == "") {
+			nm = append(nm, "")
+			continue
+		}
+		var prefix, body string
+		if ind != nil {
 			ind2 := strings.Index(l, "<")
 			if (ind2 == -1 || ind2 > ind[1]) && ind[0] < 6 {
-				//				if (ind[1]-ind[0])%2 == 0 {
-				//					nm = append(nm, l[0:ind[0]+1]+">"+l[ind[0]+1:])
-				//				} else {
-				nm = append(nm, l[0:ind[0]+1]+">"+l[ind[0]+1:])
-				//				}
+				initials := strings.TrimLeft(l[0:ind[0]], " ")
+				markerSeq := l[ind[0]:ind[1]]
+				sep, b := splitSep(l[ind[1]:])
+				prefix = " " + initials + markerSeq + ">" + sep
+				body = b
 			} else {
-				nm = append(nm, " "+from+"> "+l)
+				sep, b := splitSep(l)
+				prefix = " " + from + ">" + sep
+				body = b
 			}
 		} else {
-			nm = append(nm, " "+from+"> "+l)
+			sep, b := splitSep(l)
+			prefix = " " + from + ">" + sep
+			body = b
 		}
+		nm = append(nm, wrapQuoteLine(prefix, body, *config.Config.QuoteMargin)...)
 	}
 	//log.Print(from)
 	return nm

--- a/pkg/msgapi/message.go
+++ b/pkg/msgapi/message.go
@@ -237,7 +237,10 @@ func (m *Message) GetForward() []string {
 }
 
 // wrapQuoteLine wraps body to margin runes per segment with prefix prepended.
-// margin == 0 disables wrapping.
+// The prefix must already carry exactly one space separator after the quote
+// marker (FSC-0032); callers strip one leading space from body via
+// strings.TrimPrefix so the separator is not doubled. margin == 0 disables
+// wrapping.
 func wrapQuoteLine(prefix, body string, margin int) []string {
 	avail := margin - utf8.RuneCountInString(prefix)
 	if margin <= 0 || avail <= 0 || utf8.RuneCountInString(body) <= avail {
@@ -270,16 +273,6 @@ func wrapQuoteLine(prefix, body string, margin int) []string {
 	return segments
 }
 
-// splitSep extracts leading spaces from s as a separator and returns (sep, body).
-// If s has no leading spaces, sep defaults to a single space per FSC-0032.
-func splitSep(s string) (sep, body string) {
-	body = strings.TrimLeft(s, " ")
-	if len(body) == len(s) {
-		return " ", s
-	}
-	return s[:len(s)-len(body)], body
-}
-
 // GetQuote get quote
 func (m *Message) GetQuote() []string {
 	var nm []string
@@ -307,18 +300,15 @@ func (m *Message) GetQuote() []string {
 			if (ind2 == -1 || ind2 > ind[1]) && ind[0] < 6 {
 				initials := strings.TrimLeft(l[0:ind[0]], " ")
 				markerSeq := l[ind[0]:ind[1]]
-				sep, b := splitSep(l[ind[1]:])
-				prefix = " " + initials + markerSeq + ">" + sep
-				body = b
+				prefix = " " + initials + markerSeq + "> "
+				body = strings.TrimPrefix(l[ind[1]:], " ")
 			} else {
-				sep, b := splitSep(l)
-				prefix = " " + from + ">" + sep
-				body = b
+				prefix = " " + from + "> "
+				body = strings.TrimPrefix(l, " ")
 			}
 		} else {
-			sep, b := splitSep(l)
-			prefix = " " + from + ">" + sep
-			body = b
+			prefix = " " + from + "> "
+			body = strings.TrimPrefix(l, " ")
 		}
 		nm = append(nm, wrapQuoteLine(prefix, body, *config.Config.QuoteMargin)...)
 	}

--- a/pkg/msgapi/message_test.go
+++ b/pkg/msgapi/message_test.go
@@ -1,0 +1,110 @@
+package msgapi
+
+import (
+	"testing"
+
+	. "github.com/franela/goblin"
+)
+
+func TestWrapQuoteLine(t *testing.T) {
+	g := Goblin(t)
+	g.Describe("wrapQuoteLine", func() {
+		g.Describe("no wrapping (single segment)", func() {
+			g.It("margin == 0 disables wrapping", func() {
+				g.Assert(wrapQuoteLine(" YG> ", "some long body that would otherwise wrap", 0)).
+					Equal([]string{" YG> some long body that would otherwise wrap"})
+			})
+			g.It("body fits exactly in avail", func() {
+				// prefix " P> " = 4 runes, margin 22 → avail 18, body 18 runes
+				g.Assert(wrapQuoteLine(" P> ", "123456789012345678", 22)).
+					Equal([]string{" P> 123456789012345678"})
+			})
+			g.It("body shorter than avail", func() {
+				// prefix " P> " = 4 runes, margin 20 → avail 16, body 2 runes
+				g.Assert(wrapQuoteLine(" P> ", "hi", 20)).
+					Equal([]string{" P> hi"})
+			})
+		})
+
+		g.Describe("word wrap", func() {
+			g.It("cuts at last space within window", func() {
+				// prefix " P> " = 4 runes, margin 20 → avail 16
+				// body "hello world foo bar" (19 runes)
+				// window[0..15], runes[16]='b' → roll back to last space in [1..15] at index 15 → "hello world foo"
+				g.Assert(wrapQuoteLine(" P> ", "hello world foo bar", 20)).
+					Equal([]string{" P> hello world foo", " P> bar"})
+			})
+			g.It("keeps full window when rune after window is a space", func() {
+				// prefix " P> " = 4 runes, margin 20 → avail 16
+				// body "hello world test something" (26 runes)
+				// window[0..15], runes[16]=' ' → cut at avail → "hello world test"
+				// (does not roll back to the earlier space at index 11)
+				g.Assert(wrapQuoteLine(" P> ", "hello world test something", 20)).
+					Equal([]string{" P> hello world test", " P> something"})
+			})
+			g.It("trims leading spaces from remainder", func() {
+				// prefix " P> " = 4 runes, margin 20 → avail 16
+				// body "abcdefghijklmnop    world" (25 runes): window[0..15] has no space → hard break at 16,
+				// remainder "    world" trimmed to "world"
+				g.Assert(wrapQuoteLine(" P> ", "abcdefghijklmnop    world", 20)).
+					Equal([]string{" P> abcdefghijklmnop", " P> world"})
+			})
+			g.It("produces three segments", func() {
+				// prefix " P> " = 4 runes, margin 20 → avail 16
+				// body "the quick brown fox jumps over the lazy dog" (43 runes)
+				// iter1: window[0..15], last space at 15 → "the quick brown", remainder "fox jumps over the lazy dog"
+				// iter2: window[0..15], last space at 14 → "fox jumps over", remainder "the lazy dog"
+				// tail: "the lazy dog"
+				g.Assert(wrapQuoteLine(" P> ", "the quick brown fox jumps over the lazy dog", 20)).
+					Equal([]string{" P> the quick brown", " P> fox jumps over", " P> the lazy dog"})
+			})
+			g.It("prefix is applied to every segment unchanged", func() {
+				// prefix " YG> " = 5 runes, margin 20 → avail 15
+				// body "one two three four five six" (27 runes) wraps at least once
+				result := wrapQuoteLine(" YG> ", "one two three four five six", 20)
+				for _, s := range result {
+					// every segment must start with the prefix
+					g.Assert(s[0:len(" YG> ")]).Equal(" YG> ")
+				}
+			})
+		})
+
+		g.Describe("hard break", func() {
+			g.It("breaks a long word without spaces", func() {
+				// prefix " P> " = 4 runes, margin 20 → avail 16
+				// body "abcdefghijklmnopqrstuvwxyz" (26 runes, no space) → cut at 16
+				g.Assert(wrapQuoteLine(" P> ", "abcdefghijklmnopqrstuvwxyz", 20)).
+					Equal([]string{" P> abcdefghijklmnop", " P> qrstuvwxyz"})
+			})
+			g.It("breaks a long word into multiple chunks", func() {
+				// prefix " P> " = 4 runes, margin 20 → avail 16
+				// body "abcdefghijklmnopqrstuvwxyzabcdefghijkl" (38 runes, no space)
+				// → "abcdefghijklmnop" (16), "qrstuvwxyzabcdef" (16), "ghijkl" (6)
+				g.Assert(wrapQuoteLine(" P> ", "abcdefghijklmnopqrstuvwxyzabcdefghijkl", 20)).
+					Equal([]string{" P> abcdefghijklmnop", " P> qrstuvwxyzabcdef", " P> ghijkl"})
+			})
+		})
+
+		g.Describe("UTF-8 / runes", func() {
+			g.It("counts runes not bytes for cyrillic body", func() {
+				// prefix " ВП> " = 5 runes, margin 20 → avail 15
+				// body "здравствуй мир, это проверка" (28 runes)
+				// window[0..14], runes[15] == ' ' → cut at avail → "здравствуй мир,"
+				g.Assert(wrapQuoteLine(" ВП> ", "здравствуй мир, это проверка", 20)).
+					Equal([]string{" ВП> здравствуй мир,", " ВП> это проверка"})
+			})
+			g.It("counts runes in cyrillic prefix for avail", func() {
+				// prefix " ВП> " = 5 runes (7 bytes), margin 20 → avail 15
+				// body "проверкапроверкапроверка" (24 runes, no space) → hard break at 15
+				g.Assert(wrapQuoteLine(" ВП> ", "проверкапроверкапроверка", 20)).
+					Equal([]string{" ВП> проверкапроверк", " ВП> апроверка"})
+			})
+			g.It("fits cyrillic body without wrapping when on rune boundary", func() {
+				// prefix " P> " = 4 runes, margin 20 → avail 16
+				// body "привет, мир, при" = 16 runes ≤ avail → single
+				g.Assert(wrapQuoteLine(" P> ", "привет, мир, при", 20)).
+					Equal([]string{" P> привет, мир, при"})
+			})
+		})
+	})
+}


### PR DESCRIPTION
Wrap quoted strings longer than a margin specified in the quotemargin config parameter.

The default value is 72 runes (UTF-8 characters), 0 means no wrapping i.e. old behavour.

Also, skip blank lines from quoting.

Closes #266 